### PR TITLE
Backport expandBuff() for JavaCharStream

### DIFF
--- a/src/main/resources/templates/stream/java/JavaCharStream.template
+++ b/src/main/resources/templates/stream/java/JavaCharStream.template
@@ -20,6 +20,59 @@ class JavaCharStream extends AbstractCharStream
   }
 
   @Override
+  protected void expandBuff(boolean wrapAround)
+  {
+    char[] newbuffer = new char[bufsize + 2048];
+#if KEEP_LINE_COLUMN
+    int newbufline[] = new int[bufsize + 2048];
+    int newbufcolumn[] = new int[bufsize + 2048];
+#fi
+
+    try
+    {
+      if (wrapAround)
+      {
+        System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+        System.arraycopy(buffer, 0, newbuffer, bufsize - tokenBegin, bufpos);
+        buffer = newbuffer;
+#if KEEP_LINE_COLUMN
+
+        System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+        System.arraycopy(bufline, 0, newbufline, bufsize - tokenBegin, bufpos);
+        bufline = newbufline;
+
+        System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+        System.arraycopy(bufcolumn, 0, newbufcolumn, bufsize - tokenBegin, bufpos);
+        bufcolumn = newbufcolumn;
+#fi
+
+        bufpos += (bufsize - tokenBegin);
+    }
+    else
+    {
+        System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+        buffer = newbuffer;
+#if KEEP_LINE_COLUMN
+
+        System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+        bufline = newbufline;
+
+        System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+        bufcolumn = newbufcolumn;
+#fi
+        bufpos -= tokenBegin;
+      }
+    }
+    catch (final Exception ex)
+    {
+        throw new IllegalStateException(ex);
+    }
+    bufsize += 2048;
+    available = bufsize;
+    tokenBegin = 0;
+  }
+
+  @Override
   protected void fillBuff() throws java.io.IOException
   {
     if (maxNextCharInd == 4096)

--- a/src/main/resources/templates/stream/java/modern/JavaCharStream.template
+++ b/src/main/resources/templates/stream/java/modern/JavaCharStream.template
@@ -19,6 +19,59 @@ class JavaCharStream extends AbstractCharStream
     inputStream.close (); 
   }
 
+  @Override
+  protected void expandBuff(boolean wrapAround)
+  {
+    char[] newbuffer = new char[bufsize + 2048];
+#if KEEP_LINE_COLUMN
+    int newbufline[] = new int[bufsize + 2048];
+    int newbufcolumn[] = new int[bufsize + 2048];
+#fi
+
+    try
+    {
+      if (wrapAround)
+      {
+        System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+        System.arraycopy(buffer, 0, newbuffer, bufsize - tokenBegin, bufpos);
+        buffer = newbuffer;
+#if KEEP_LINE_COLUMN
+
+        System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+        System.arraycopy(bufline, 0, newbufline, bufsize - tokenBegin, bufpos);
+        bufline = newbufline;
+
+        System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+        System.arraycopy(bufcolumn, 0, newbufcolumn, bufsize - tokenBegin, bufpos);
+        bufcolumn = newbufcolumn;
+#fi
+
+        bufpos += (bufsize - tokenBegin);
+    }
+    else
+    {
+        System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+        buffer = newbuffer;
+#if KEEP_LINE_COLUMN
+
+        System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+        bufline = newbufline;
+
+        System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+        bufcolumn = newbufcolumn;
+#fi
+        bufpos -= tokenBegin;
+      }
+    }
+    catch (final Exception ex)
+    {
+        throw new IllegalStateException(ex);
+    }
+    bufsize += 2048;
+    available = bufsize;
+    tokenBegin = 0;
+  }
+
   protected void fillBuff() throws java.io.IOException
   {
     if (maxNextCharInd == 4096)


### PR DESCRIPTION
I am not exactly sure why, but I only have had this happen in Java 11. The behavior that causes this bug doesn't seem to happen in Java 8. 
The scenario I came across this in is when attempting to parse something
very large, about 20MB. 
This is just what worked for me and what I could figure through
working backwards in the debugger and looking at the git history, 
I don't really understand why for example SimpleCharStream seems
to treat this variable in one way and JavaCharStream another, for example.

The implementation of expandBuff() in AbstractCharStream sets
maxNextCharInd to be the the buffer position. However this buffer
size is not the same as the one of nextCharBuf, which is fixed at
4096. JavaCharStream uses maxCharInd to bound nextCharInd, which
it uses to access nextCharBuf in readByte(). Therefore this can
cause OOB access when JavaCharStream tries to read something big
enough to cause expandBuff() to be called.

Thanks for updating this project and the maven plugin, I hope this patch doesn't end up
being a goose chase for you. 

